### PR TITLE
Make jug.ru logo link absolute

### DIFF
--- a/source/_includes/custom/asides/partners.html
+++ b/source/_includes/custom/asides/partners.html
@@ -1,4 +1,4 @@
 <section>
   <h1>Партнеры</h1>
-  <a href="http://jug.ru"><img src="images/jugru_logo.png"></a>
+  <a href="http://jug.ru"><img src="/images/jugru_logo.png"></a>
 </section>


### PR DESCRIPTION
Otherwise, the logo is visible on home page only